### PR TITLE
Don't overwrite user git config

### DIFF
--- a/health-check.sh
+++ b/health-check.sh
@@ -58,9 +58,6 @@ done
 
 if [[ $commit == true ]]
 then
-  # Let's make Vijaye the most productive person on GitHub.
-  git config --global user.name 'Vijaye Raji'
-  git config --global user.email 'vijaye@statsig.com'
   git add -A --force logs/
   git commit -am '[Automated] Update Health Check Logs'
   git push


### PR DESCRIPTION
Users need to have a git configured to be able to use git push so no need to force a name and email. This avoid unfortunate overwrite of user config.

I tested statuspage and it took me sometime to understand why all my git config had changed, not very nice.